### PR TITLE
Simplify some of the `match` expression usages

### DIFF
--- a/rustwasm/src/core.rs
+++ b/rustwasm/src/core.rs
@@ -246,9 +246,8 @@ fn slurp(args: Vec<MalType>) -> MalResult {
     };
 
     let mut s = String::new();
-    match file.read_to_string(&mut s) {
-        Err(why) => return mal_error!(format!("can't read {}, {}", str, why.description())),
-        _ => {}
+    if let Err(why) = file.read_to_string(&mut s) {
+        return mal_error!(format!("can't read {}, {}", str, why.description()));
     };
 
     Ok(MalString(s))
@@ -633,9 +632,8 @@ fn first(args: Vec<MalType>) -> MalResult {
 
     let list = args.get(0).unwrap();
 
-    match list {
-        &MalNil => return Ok(MalNil),
-        _ => {}
+    if list == &MalNil {
+        return Ok(MalNil);
     };
 
     let list = seq!(list.clone());
@@ -655,9 +653,8 @@ fn rest(args: Vec<MalType>) -> MalResult {
 
     let list = args.get(0).unwrap();
 
-    match list {
-        &MalNil => return Ok(MalList(vec![], Box::new(None))),
-        _ => {}
+    if list == &MalNil {
+        return Ok(MalList(vec![], Box::new(None)));
     };
 
     let list = seq!(list.clone());

--- a/rustwasm/src/step0_repl.rs
+++ b/rustwasm/src/step0_repl.rs
@@ -18,8 +18,8 @@ fn print(exp: String) -> Result<String, MalError> {
     Ok(exp)
 }
 
-pub fn rep(str: String) -> Result<String, MalError> {
-    let ast = try!(read(str));
+pub fn rep(str: &str) -> Result<String, MalError> {
+    let ast = try!(read(str.to_string()));
     let exp = try!(eval(ast, "".to_string()));
     print(exp)
 }
@@ -30,7 +30,7 @@ pub fn run() {
         if let None = line {
             break;
         }
-        let result = rep(line.unwrap());
+        let result = rep(&line.unwrap());
         match result {
             Ok(message) => println(message),
             Err(MalError::ErrorMessage(message)) => println(message),

--- a/rustwasm/src/step1_read_print.rs
+++ b/rustwasm/src/step1_read_print.rs
@@ -6,10 +6,7 @@ use printer::{pr_str, println};
 
 // READ
 fn read(str: String) -> MalResult {
-    match read_str(str) {
-        Ok(v) => Ok(v),
-        Err(v) => mal_error!(v),
-    }
+    read_str(str).or_else(|e| mal_error!(e))
 }
 
 // EVAL
@@ -22,8 +19,8 @@ fn print(exp: MalType) -> Result<String, MalError> {
     Ok(pr_str(&exp, true))
 }
 
-pub fn rep(str: String) -> Result<String, MalError> {
-    let ast = try!(read(str));
+pub fn rep(str: &str) -> Result<String, MalError> {
+    let ast = try!(read(str.to_string()));
     let exp = try!(eval(ast, "".to_string()));
     print(exp)
 }
@@ -34,7 +31,7 @@ pub fn run() {
         if let None = line {
             break;
         }
-        let result = rep(line.unwrap());
+        let result = rep(&line.unwrap());
         match result {
             Ok(message) => println(message),
             Err(MalError::ErrorMessage(message)) => println(message),

--- a/rustwasm/src/step2_eval.rs
+++ b/rustwasm/src/step2_eval.rs
@@ -10,10 +10,7 @@ use printer::{pr_str, println};
 
 // READ
 fn read(str: String) -> MalResult {
-    match read_str(str) {
-        Ok(v) => Ok(v),
-        Err(v) => mal_error!(v),
-    }
+    read_str(str).or_else(|e| mal_error!(e))
 }
 
 fn eval_ast(ast: MalType, env: Env) -> MalResult {
@@ -80,8 +77,8 @@ fn print(exp: MalType) -> Result<String, MalError> {
     Ok(pr_str(&exp, true))
 }
 
-pub fn rep(str: String, env: &Env) -> Result<String, MalError> {
-    let ast = try!(read(str));
+pub fn rep(str: &str, env: &Env) -> Result<String, MalError> {
+    let ast = try!(read(str.to_string()));
     let exp = try!(eval(ast, env.clone()));
     print(exp)
 }
@@ -152,7 +149,7 @@ pub fn run() {
         if let None = line {
             break;
         }
-        let result = rep(line.unwrap(), &repl_env);
+        let result = rep(&line.unwrap(), &repl_env);
         match result {
             Ok(message) => println(message),
             Err(MalError::ErrorMessage(message)) => println(message),

--- a/rustwasm/src/step3_env.rs
+++ b/rustwasm/src/step3_env.rs
@@ -11,10 +11,7 @@ use printer::{pr_str, println};
 
 // READ
 fn read(str: String) -> MalResult {
-    match read_str(str) {
-        Ok(v) => Ok(v),
-        Err(v) => mal_error!(v),
-    }
+    read_str(str).or_else(|e| mal_error!(e))
 }
 
 fn eval_ast(ast: MalType, env: Env) -> MalResult {
@@ -124,8 +121,8 @@ fn print(exp: MalType) -> Result<String, MalError> {
     Ok(pr_str(&exp, true))
 }
 
-pub fn rep(str: String, env: &Env) -> Result<String, MalError> {
-    let ast = try!(read(str));
+pub fn rep(str: &str, env: &Env) -> Result<String, MalError> {
+    let ast = try!(read(str.to_string()));
     let exp = try!(eval(ast, env.clone()));
     print(exp)
 }
@@ -194,7 +191,7 @@ pub fn run() {
         if let None = line {
             break;
         }
-        let result = rep(line.unwrap(), &repl_env);
+        let result = rep(&line.unwrap(), &repl_env);
         match result {
             Ok(message) => println(message),
             Err(MalError::ErrorMessage(message)) => println(message),

--- a/rustwasm/src/step5_tco.rs
+++ b/rustwasm/src/step5_tco.rs
@@ -12,10 +12,7 @@ use printer::{pr_str, println};
 
 // READ
 fn read(str: String) -> MalResult {
-    match read_str(str) {
-        Ok(v) => Ok(v),
-        Err(v) => mal_error!(v),
-    }
+    read_str(str).or_else(|e| mal_error!(e))
 }
 
 fn eval_ast(ast: MalType, env: Env) -> MalResult {
@@ -188,10 +185,14 @@ fn print(exp: MalType) -> Result<String, MalError> {
     Ok(pr_str(&exp, true))
 }
 
-pub fn rep(str: String, env: &Env) -> Result<String, MalError> {
-    let ast = try!(read(str));
+pub fn rep(str: &str, env: &Env) -> Result<String, MalError> {
+    let ast = try!(read(str.to_string()));
     let exp = try!(eval(ast, env.clone()));
     print(exp)
+}
+
+fn rep_or_panic(str: &str, env: &Env, line: u32) {
+    rep(str, env).expect(&format!("rep on `{}` failed at {}:{}", str, file!(), line));
 }
 
 pub fn new_repl_env() -> Env {
@@ -203,11 +204,8 @@ pub fn new_repl_env() -> Env {
     }
 
     // core.mal: defined using the language itself
-    match rep("(def! not (fn* (a) (if a false true)))".to_string(),
-              &repl_env) {
-        Err(x) => panic!("{:?}", x),
-        _ => {}
-    };
+    rep_or_panic("(def! not (fn* (a) (if a false true)))",
+                 &repl_env, line!());
 
     repl_env
 }
@@ -220,7 +218,7 @@ pub fn run() {
         if let None = line {
             break;
         }
-        let result = rep(line.unwrap(), &repl_env);
+        let result = rep(&line.unwrap(), &repl_env);
         match result {
             Ok(message) => println(message),
             Err(MalError::ErrorMessage(message)) => println(message),

--- a/rustwasm/src/step7_quote.rs
+++ b/rustwasm/src/step7_quote.rs
@@ -14,10 +14,7 @@ use printer::{pr_str, println};
 
 // READ
 fn read(str: String) -> MalResult {
-    match read_str(str) {
-        Ok(v) => Ok(v),
-        Err(v) => mal_error!(v),
-    }
+    read_str(str).or_else(|e| mal_error!(e))
 }
 
 fn is_pair(ast: MalType) -> bool {
@@ -51,25 +48,22 @@ fn quasiquote(ast: MalType) -> MalResult {
 
     if is_pair(arg1.clone()) {
         let arg1_list = seq!(arg1.clone());
-        match arg1_list.get(0) {
-            Some(arg11) => {
-                if let &MalSymbol(ref symbol) = arg11 {
-                    if symbol == "splice-unquote" {
-                        let arg12 = match arg1_list.get(1) {
-                            Some(ast) => ast,
-                            None => {
-                                return mal_error!("splice-unquote: 1 argument required".to_string())
-                            }
-                        };
-                        return Ok(MalList(vec![MalSymbol("concat".to_string()),
-                                               arg12.clone(),
-                                               try!(quasiquote(MalList((&list[1..]).to_vec(),
-                                                                       Box::new(None))))],
-                                          Box::new(None)));
-                    }
+        if let Some(arg11) = arg1_list.get(0) {
+            if let &MalSymbol(ref symbol) = arg11 {
+                if symbol == "splice-unquote" {
+                    let arg12 = match arg1_list.get(1) {
+                        Some(ast) => ast,
+                        None => {
+                            return mal_error!("splice-unquote: 1 argument required".to_string())
+                        }
+                    };
+                    return Ok(MalList(vec![MalSymbol("concat".to_string()),
+                                           arg12.clone(),
+                                           try!(quasiquote(MalList((&list[1..]).to_vec(),
+                                                                   Box::new(None))))],
+                                      Box::new(None)));
                 }
             }
-            None => {}
         };
 
     }
@@ -267,10 +261,14 @@ fn print(exp: MalType) -> Result<String, MalError> {
     Ok(pr_str(&exp, true))
 }
 
-pub fn rep(str: String, env: &Env) -> Result<String, MalError> {
-    let ast = try!(read(str));
+pub fn rep(str: &str, env: &Env) -> Result<String, MalError> {
+    let ast = try!(read(str.to_string()));
     let exp = try!(eval(ast, env.clone()));
     print(exp)
+}
+
+fn rep_or_panic(str: &str, env: &Env, line: u32) {
+    rep(str, env).expect(&format!("rep on `{}` failed at {}:{}", str, file!(), line));
 }
 
 pub fn new_repl_env() -> Env {
@@ -284,17 +282,10 @@ pub fn new_repl_env() -> Env {
     repl_env.set("eval".to_string(), func_for_eval(eval, repl_env.clone()));
 
     // core.mal: defined using the language itself
-    match rep("(def! not (fn* (a) (if a false true)))".to_string(),
-              &repl_env) {
-        Err(x) => panic!("{:?}", x),
-        _ => {}
-    };
-    match rep(r##"(def! load-file (fn* (f) (eval (read-string (str "(do " (slurp f) ")")))))"##
-                  .to_string(),
-              &repl_env) {
-        Err(x) => panic!("{:?}", x),
-        _ => {}
-    };
+    rep_or_panic("(def! not (fn* (a) (if a false true)))",
+                 &repl_env, line!());
+    rep_or_panic(r##"(def! load-file (fn* (f) (eval (read-string (str "(do " (slurp f) ")")))))"##,
+                 &repl_env, line!());
 
     repl_env
 }
@@ -302,7 +293,7 @@ pub fn new_repl_env() -> Env {
 #[cfg(not(target_arch="wasm32"))]
 fn load_file(source: String, env: &Env) {
     let load = format!(r##"(load-file "{}")"##, source);
-    let ret = rep(load, env);
+    let ret = rep(&load, env);
     match ret {
         Ok(_) => process::exit(0),
         Err(v) => {
@@ -335,7 +326,7 @@ pub fn run(args: Vec<String>) {
         if let None = line {
             break;
         }
-        let result = rep(line.unwrap(), &repl_env);
+        let result = rep(&line.unwrap(), &repl_env);
         match result {
             Ok(message) => println(message),
             Err(MalError::ErrorMessage(message)) => println(message),

--- a/rustwasm/src/step8_macros.rs
+++ b/rustwasm/src/step8_macros.rs
@@ -14,10 +14,7 @@ use printer::{pr_str, println};
 
 // READ
 fn read(str: String) -> MalResult {
-    match read_str(str) {
-        Ok(v) => Ok(v),
-        Err(v) => mal_error!(v),
-    }
+    read_str(str).or_else(|e| mal_error!(e))
 }
 
 fn is_pair(ast: MalType) -> bool {
@@ -112,25 +109,22 @@ fn quasiquote(ast: MalType) -> MalResult {
 
     if is_pair(arg1.clone()) {
         let arg1_list = seq!(arg1.clone());
-        match arg1_list.get(0) {
-            Some(arg11) => {
-                if let &MalSymbol(ref symbol) = arg11 {
-                    if symbol == "splice-unquote" {
-                        let arg12 = match arg1_list.get(1) {
-                            Some(ast) => ast,
-                            None => {
-                                return mal_error!("splice-unquote: 1 argument required".to_string())
-                            }
-                        };
-                        return Ok(MalList(vec![MalSymbol("concat".to_string()),
-                                               arg12.clone(),
-                                               try!(quasiquote(MalList((&list[1..]).to_vec(),
-                                                                       Box::new(None))))],
-                                          Box::new(None)));
-                    }
+        if let Some(arg11) = arg1_list.get(0) {
+            if let &MalSymbol(ref symbol) = arg11 {
+                if symbol == "splice-unquote" {
+                    let arg12 = match arg1_list.get(1) {
+                        Some(ast) => ast,
+                        None => {
+                            return mal_error!("splice-unquote: 1 argument required".to_string())
+                        }
+                    };
+                    return Ok(MalList(vec![MalSymbol("concat".to_string()),
+                                            arg12.clone(),
+                                            try!(quasiquote(MalList((&list[1..]).to_vec(),
+                                                                    Box::new(None))))],
+                                        Box::new(None)));
                 }
             }
-            None => {}
         };
 
     }
@@ -374,10 +368,14 @@ fn print(exp: MalType) -> Result<String, MalError> {
     Ok(pr_str(&exp, true))
 }
 
-pub fn rep(str: String, env: &Env) -> Result<String, MalError> {
-    let ast = try!(read(str));
+pub fn rep(str: &str, env: &Env) -> Result<String, MalError> {
+    let ast = try!(read(str.to_string()));
     let exp = try!(eval(ast, env.clone()));
     print(exp)
+}
+
+fn rep_or_panic(str: &str, env: &Env, line: u32) {
+    rep(str, env).expect(&format!("rep on `{}` failed at {}:{}", str, file!(), line));
 }
 
 pub fn new_repl_env() -> Env {
@@ -391,29 +389,14 @@ pub fn new_repl_env() -> Env {
     repl_env.set("eval".to_string(), func_for_eval(eval, repl_env.clone()));
 
     // core.mal: defined using the language itself
-    match rep("(def! not (fn* (a) (if a false true)))".to_string(),
-              &repl_env) {
-        Err(x) => panic!("{:?}", x),
-        _ => {}
-    };
-    match rep(r##"(def! load-file (fn* (f) (eval (read-string (str "(do " (slurp f) ")")))))"##
-                  .to_string(),
-              &repl_env) {
-        Err(x) => panic!("{:?}", x),
-        _ => {}
-    };
-    match rep(r##"(defmacro! cond (fn* (& xs) (if (> (count xs) 0) (list 'if (first xs) (if (> (count xs) 1) (nth xs 1) (throw "odd number of forms to cond")) (cons 'cond (rest (rest xs)))))))"##
-                  .to_string(),
-              &repl_env) {
-        Err(x) => panic!("{:?}", x),
-        _ => {}
-    };
-    match rep(r##"(defmacro! or (fn* (& xs) (if (empty? xs) nil (if (= 1 (count xs)) (first xs) `(let* (or_FIXME ~(first xs)) (if or_FIXME or_FIXME (or ~@(rest xs))))))))"##
-                  .to_string(),
-              &repl_env) {
-        Err(x) => panic!("{:?}", x),
-        _ => {}
-    };
+    rep_or_panic("(def! not (fn* (a) (if a false true)))",
+                 &repl_env, line!());
+    rep_or_panic(r##"(def! load-file (fn* (f) (eval (read-string (str "(do " (slurp f) ")")))))"##,
+                 &repl_env, line!());
+    rep_or_panic(r##"(defmacro! cond (fn* (& xs) (if (> (count xs) 0) (list 'if (first xs) (if (> (count xs) 1) (nth xs 1) (throw "odd number of forms to cond")) (cons 'cond (rest (rest xs)))))))"##,
+                 &repl_env, line!());
+    rep_or_panic(r##"(defmacro! or (fn* (& xs) (if (empty? xs) nil (if (= 1 (count xs)) (first xs) `(let* (or_FIXME ~(first xs)) (if or_FIXME or_FIXME (or ~@(rest xs))))))))"##,
+                 &repl_env, line!());
 
     repl_env
 }
@@ -421,7 +404,7 @@ pub fn new_repl_env() -> Env {
 #[cfg(not(target_arch="wasm32"))]
 fn load_file(source: String, env: &Env) {
     let load = format!(r##"(load-file "{}")"##, source);
-    let ret = rep(load, env);
+    let ret = rep(&load, env);
     match ret {
         Ok(_) => process::exit(0),
         Err(v) => {
@@ -454,7 +437,7 @@ pub fn run(args: Vec<String>) {
         if let None = line {
             break;
         }
-        let result = rep(line.unwrap(), &repl_env);
+        let result = rep(&line.unwrap(), &repl_env);
         match result {
             Ok(message) => println(message),
             Err(MalError::ErrorMessage(message)) => println(message),

--- a/rustwasm/src/stepA_mal.rs
+++ b/rustwasm/src/stepA_mal.rs
@@ -14,10 +14,7 @@ use printer::{pr_str, println};
 
 // READ
 fn read(str: String) -> MalResult {
-    match read_str(str) {
-        Ok(v) => Ok(v),
-        Err(v) => mal_error!(v),
-    }
+    read_str(str).or_else(|e| mal_error!(e))
 }
 
 fn is_pair(ast: MalType) -> bool {
@@ -112,25 +109,22 @@ fn quasiquote(ast: MalType) -> MalResult {
 
     if is_pair(arg1.clone()) {
         let arg1_list = seq!(arg1.clone());
-        match arg1_list.get(0) {
-            Some(arg11) => {
-                if let &MalSymbol(ref symbol) = arg11 {
-                    if symbol == "splice-unquote" {
-                        let arg12 = match arg1_list.get(1) {
-                            Some(ast) => ast,
-                            None => {
-                                return mal_error!("splice-unquote: 1 argument required".to_string())
-                            }
-                        };
-                        return Ok(MalList(vec![MalSymbol("concat".to_string()),
-                                               arg12.clone(),
-                                               try!(quasiquote(MalList((&list[1..]).to_vec(),
-                                                                       Box::new(None))))],
-                                          Box::new(None)));
-                    }
+        if let Some(arg11) = arg1_list.get(0) {
+            if let &MalSymbol(ref symbol) = arg11 {
+                if symbol == "splice-unquote" {
+                    let arg12 = match arg1_list.get(1) {
+                         Some(ast) => ast,
+                        None => {
+                            return mal_error!("splice-unquote: 1 argument required".to_string())
+                        }
+                    };
+                    return Ok(MalList(vec![MalSymbol("concat".to_string()),
+                                           arg12.clone(),
+                                           try!(quasiquote(MalList((&list[1..]).to_vec(),
+                                                                   Box::new(None))))],
+                                      Box::new(None)));
                 }
             }
-            None => {}
         };
 
     }
@@ -423,10 +417,14 @@ fn print(exp: MalType) -> Result<String, MalError> {
     Ok(pr_str(&exp, true))
 }
 
-pub fn rep(str: String, env: &Env) -> Result<String, MalError> {
-    let ast = try!(read(str));
+pub fn rep(str: &str, env: &Env) -> Result<String, MalError> {
+    let ast = try!(read(str.to_string()));
     let exp = try!(eval(ast, env.clone()));
     print(exp)
+}
+
+fn rep_or_panic(str: &str, env: &Env, line: u32) {
+    rep(str, env).expect(&format!("rep on `{}` failed at {}:{}.", str, file!(), line));
 }
 
 pub fn new_repl_env() -> Env {
@@ -440,46 +438,18 @@ pub fn new_repl_env() -> Env {
     repl_env.set("eval".to_string(), func_for_eval(eval, repl_env.clone()));
 
     // core.mal: defined using the language itself
-    match rep(r##"(def! *host-language* "rust+wasm")""##.to_string(),
-              &repl_env) {
-        Err(x) => panic!("{:?}", x),
-        _ => {}
-    };
-    match rep("(def! not (fn* (a) (if a false true)))".to_string(),
-              &repl_env) {
-        Err(x) => panic!("{:?}", x),
-        _ => {}
-    };
-    match rep(r##"(def! load-file (fn* (f) (eval (read-string (str "(do " (slurp f) ")")))))"##
-                  .to_string(),
-              &repl_env) {
-        Err(x) => panic!("{:?}", x),
-        _ => {}
-    };
-    match rep(r##"(defmacro! cond (fn* (& xs) (if (> (count xs) 0) (list 'if (first xs) (if (> (count xs) 1) (nth xs 1) (throw "odd number of forms to cond")) (cons 'cond (rest (rest xs)))))))"##
-                  .to_string(),
-              &repl_env) {
-        Err(x) => panic!("{:?}", x),
-        _ => {}
-    };
-    match rep(r##"(def! *gensym-counter* (atom 0))"##.to_string(),
-              &repl_env) {
-        Err(x) => panic!("{:?}", x),
-        _ => {}
-    };
-    match rep(r##"(def! gensym (fn* [] (symbol (str "G__" (swap! *gensym-counter* (fn* [x] (+ 1 x)))))))"##
-                  .to_string(),
-              &repl_env) {
-        Err(x) => panic!("{:?}", x),
-        _ => {}
-    };
-
-    match rep(r##"(defmacro! or (fn* (& xs) (if (empty? xs) nil (if (= 1 (count xs)) (first xs) (let* (condvar (gensym)) `(let* (~condvar ~(first xs)) (if ~condvar ~condvar (or ~@(rest xs)))))))))"##
-                  .to_string(),
-              &repl_env) {
-        Err(x) => panic!("{:?}", x),
-        _ => {}
-    };
+    rep_or_panic(r##"(def! *host-language* "rust+wasm")""##,
+                 &repl_env, line!());
+    rep_or_panic(r##"(def! load-file (fn* (f) (eval (read-string (str "(do " (slurp f) ")")))))"##,
+                 &repl_env, line!());
+    rep_or_panic(r##"(defmacro! cond (fn* (& xs) (if (> (count xs) 0) (list 'if (first xs) (if (> (count xs) 1) (nth xs 1) (throw "odd number of forms to cond")) (cons 'cond (rest (rest xs)))))))"##,
+                 &repl_env, line!());
+    rep_or_panic(r##"(def! *gensym-counter* (atom 0))"##,
+                 &repl_env, line!());
+    rep_or_panic(r##"(def! gensym (fn* [] (symbol (str "G__" (swap! *gensym-counter* (fn* [x] (+ 1 x)))))))"##,
+                 &repl_env, line!());
+    rep_or_panic(r##"(defmacro! or (fn* (& xs) (if (empty? xs) nil (if (= 1 (count xs)) (first xs) (let* (condvar (gensym)) `(let* (~condvar ~(first xs)) (if ~condvar ~condvar (or ~@(rest xs)))))))))"##,
+                 &repl_env, line!());
 
     repl_env
 }
@@ -487,7 +457,7 @@ pub fn new_repl_env() -> Env {
 #[cfg(not(target_arch="wasm32"))]
 fn load_file(source: String, env: &Env) {
     let load = format!(r##"(load-file "{}")"##, source);
-    let ret = rep(load, env);
+    let ret = rep(&load, env);
     match ret {
         Ok(_) => process::exit(0),
         Err(v) => {
@@ -515,18 +485,15 @@ pub fn run(args: Vec<String>) {
         return;
     }
 
-    match rep(r##"(println (str "Mal [" *host-language* "]"))"##.to_string(),
-              &repl_env) {
-        Err(x) => panic!("{:?}", x),
-        _ => {}
-    };
+    rep_or_panic(r##"(println (str "Mal [" *host-language* "]"))"##,
+                 &repl_env, line!());
 
     loop {
         let line = mal_readline("user> ");
         if let None = line {
             break;
         }
-        let result = rep(line.unwrap(), &repl_env);
+        let result = rep(&line.unwrap(), &repl_env);
         match result {
             Ok(message) => println(message),
             Err(MalError::ErrorMessage(message)) => println(message),


### PR DESCRIPTION
- Replace `match ... { Ok(v) => Ok(v), Err(v) => ...}` with `.or_else()` combinator.
- Replace `match`es with single match arm with `if let` or `if`.
- Change `rep()`'s first argument type from String to &str.
- Introduce a boilerplate function `rep_or_panic()` for simplified error processing and better error reporting:
  * (before)
     ```
     thread 'main' panicked at 'unexpected EOF', src/stepA_mal.rs:448
     ```
  * (after)
     ```
     thread 'main' panicked at 'rep on `(def! *host-language* "rust+wasm"("` failed at 
     src/stepA_mal.rs:445: unexpected EOF', ...
     ```