### PR TITLE
Address Clippy warning "temporary_cstring_as_ptr"

### DIFF
--- a/rustwasm/src/readline.rs
+++ b/rustwasm/src/readline.rs
@@ -27,8 +27,9 @@ mod normal {
     }
 
     pub fn add_history(line: &str) {
+        let cline = CString::new(line).unwrap();
         unsafe {
-            ext_readline::add_history(CString::new(line).unwrap().as_ptr());
+            ext_readline::add_history(cline.as_ptr());
         }
     }
 


### PR DESCRIPTION
Clippy emits the following warning.

```
warning: you are getting the inner pointer of a temporary `CString`
  --> src/readline.rs:31:39
   |
31 |             ext_readline::add_history(CString::new(line).unwrap().as_ptr());
   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: #[warn(temporary_cstring_as_ptr)] on by default
   = note: that pointer will be invalid outside this expression
help: assign the `CString` to a variable to extend its lifetime
  --> src/readline.rs:31:39
   |
31 |             ext_readline::add_history(CString::new(line).unwrap().as_ptr());
   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#temporary_cstring_as_ptr
```

As Clippy suggests, this PR binds the CString to a variable to extend its lifetime. I believe this warning for this particular code is harmless, but I would rather follow the suggestion as it is generally a good practice.